### PR TITLE
chore: フィボナッチ数列の解を求める関数の追加

### DIFF
--- a/src/pkg/Fibonacci.go
+++ b/src/pkg/Fibonacci.go
@@ -1,0 +1,13 @@
+package pkg
+
+// Fibonacci is a function that returns the n-th number of the Fibonacci sequence.
+// 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 ...
+func Fibonacci(n int) int {
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return 1
+	}
+	return Fibonacci(n-1) + Fibonacci(n-2)
+}

--- a/src/pkg/Fibonacci_test.go
+++ b/src/pkg/Fibonacci_test.go
@@ -1,0 +1,64 @@
+package pkg
+
+import (
+	"testing"
+)
+
+// TestFibonacci is a test function for the Fibonacci function.
+// 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 ...
+func TestFibonacci(t *testing.T) {
+
+	tests := []struct {
+		arg  int
+		want int
+	}{
+		{
+			arg:  0,
+			want: 0,
+		},
+		{
+			arg:  1,
+			want: 1,
+		},
+		{
+			arg:  2,
+			want: 1,
+		},
+		{
+			arg:  3,
+			want: 2,
+		},
+		{
+			arg:  4,
+			want: 3,
+		},
+		{
+			arg:  5,
+			want: 5,
+		},
+		{
+			arg:  20,
+			want: 6765,
+		},
+		{
+			arg:  50,
+			want: 12586269025,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("test fibonacci", func(t *testing.T) {
+			if got := Fibonacci(tt.arg); got != tt.want {
+				t.Errorf("Fibonacci() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
+// ベンチマークテスト
+func BenchmarkFibonacci(b *testing.B) {
+	for n := 0; n < 40; n++ {
+		Fibonacci(n)
+	}
+}


### PR DESCRIPTION
フィボナッチ数列の解を求める関数を追加しました。

ベンチマークの結果は以下のとおりです。
``` console
GOROOT=/Users/usr7000326/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.darwin-arm64 #gosetup
GOPATH=/Users/usr7000326/go #gosetup
/Users/usr7000326/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.darwin-arm64/bin/go test -c -o /Users/usr7000326/Library/Caches/JetBrains/GoLand2024.1/tmp/GoLand/___BenchmarkFibonacci_in_ms_omori_pkg.test ms-omori/pkg #gosetup
/Users/usr7000326/Library/Caches/JetBrains/GoLand2024.1/tmp/GoLand/___BenchmarkFibonacci_in_ms_omori_pkg.test -test.v -test.paniconexit0 -test.bench ^\QBenchmarkFibonacci\E$ -test.run ^$
goos: darwin
goarch: arm64
pkg: ms-omori/pkg
cpu: Apple M3 Pro
BenchmarkFibonacci
BenchmarkFibonacci-12    	1000000000	         0.5719 ns/op
PASS

Process finished with the exit code 0
```